### PR TITLE
fix: Add powershell script to install WebView2, closes #9

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,6 +46,11 @@ jobs:
       with:
         submodules: 'true'
 
+    - name: Install WebView2 on Windows
+      if: runner.os == 'Windows'
+      uses: nuget/setup-nuget@v2
+      run: nuget install Microsoft.Web.WebView2 -Version 1.0.1901.177
+
     - name: Build on Windows
       if: runner.os == 'Windows'
       run: .\scripts\build\windows_release.ps1

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,10 +45,13 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
+        
+    - name: Setup NuGet on Windows
+      if: runner.os == 'Windows'
+      uses: nuget/setup-nuget@v2
 
     - name: Install WebView2 on Windows
       if: runner.os == 'Windows'
-      uses: nuget/setup-nuget@v2
       run: nuget install Microsoft.Web.WebView2 -Version 1.0.1901.177
 
     - name: Build on Windows

--- a/scripts/build/windows_release.ps1
+++ b/scripts/build/windows_release.ps1
@@ -9,10 +9,6 @@ if (Test-Path -Path $VST3Path) {
 # Create build output directories
 New-Item -ItemType Directory -Path 'build\release' -Force
 
-# Install WebView2 dependency for the plugin
-Register-PackageSource -provider NuGet -name nugetRepository -location https://www.nuget.org/api/v2
-Install-Package Microsoft.Web.WebView2 -Scope CurrentUser -RequiredVersion 1.0.1901.177 -Source nugetRepository
-
 # Download models
 & ".\scripts\models.ps1"
 

--- a/scripts/build/windows_release.ps1
+++ b/scripts/build/windows_release.ps1
@@ -9,6 +9,10 @@ if (Test-Path -Path $VST3Path) {
 # Create build output directories
 New-Item -ItemType Directory -Path 'build\release' -Force
 
+# Install WebView2 dependency for the plugin
+Register-PackageSource -provider NuGet -name nugetRepository -location https://www.nuget.org/api/v2
+Install-Package Microsoft.Web.WebView2 -Scope CurrentUser -RequiredVersion 1.0.1901.177 -Source nugetRepository
+
 # Download models
 & ".\scripts\models.ps1"
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the Windows release build script by adding a PowerShell command to install the WebView2 dependency, ensuring the plugin has all necessary components.

Bug Fixes:
- Add a PowerShell script to install the WebView2 dependency for the plugin, addressing a missing dependency issue.

Build:
- Include a step in the Windows release build script to register a NuGet package source and install the WebView2 package.

<!-- Generated by sourcery-ai[bot]: end summary -->